### PR TITLE
Send keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ Multiple vranger instances can be run in parallel.
 
 #Installation
 
-Vranger requires ranger, tmux, vim, and bash.  Client/server communication in
-vim uses X11, so this will not work without an X server running.  Both the
-vranger and vrim scripts should be in your PATH.
+Vranger requires ranger, tmux, and vim.  When vim supports client/server
+communication via X11, it will use that to pass the commands.  When vim
+client/server support is not available, the commands are passed by the tmux
+send-keys facility, which might be kinda fragile.
+
+Both the vranger and vrim scripts should be in your PATH.
 
 In Arch Linux, you can install via the
 [AUR](https://aur.archlinux.org/packages/vranger-git/) or the included

--- a/vranger
+++ b/vranger
@@ -31,14 +31,34 @@ EDITOR="$(cd $(dirname $0) && pwd)/vrim" ranger
 
 # Ranger is now finished, and we need to do some cleanup.
 
+if tmux has-session -t $VRIM_ID >/dev/null 2>&1; then
+  VRIM_HAS_TMUX_SESSION=1
+fi
+
+_send_vim() {
+  if [ "$VRIM_HAS_TMUX_SESSION" != "1" ]; then
+    return
+  fi
+
+  if [ "$VRIM_SENDKEYS" = "1" ]; then
+    tmux send-keys -t $VRIM_ID Escape
+    tmux send-keys -t $VRIM_ID -l "$1"
+    tmux send-keys -t $VRIM_ID Enter
+  else
+    vim --servername $VRIM_ID --remote-send "<Esc>$1<CR>" >/dev/null 2>&1
+  fi
+}
+
 # Prevent the user from inadvertently detaching and accidentally
-# leaving a running tmux instance
-vim --servername $VRIM_ID --remote-send "<Esc>:nunmap $DETACH<CR>" >/dev/null 2>&1
+# leaving a running tmux instance.
+_send_vim ":nunmap $DETACH"
 
 # Ask vim to quit
-vim --servername $VRIM_ID --remote-send '<Esc>:qa<CR>' >/dev/null 2>&1
+_send_vim ":qa"
 
 # Reattach to tmux.  If there were no unsaved changes, vim and tmux should both
 # exit.  Otherwise, vim gets a chance to prompt the user, and the user must
 # exit the session normally.
-tmux -2 attach -t $VRIM_ID >/dev/null 2>&1
+if [ "$VRIM_HAS_TMUX_SESSION" = "1" ]; then
+  tmux -2 attach -t $VRIM_ID >/dev/null 2>&1
+fi

--- a/vranger
+++ b/vranger
@@ -10,6 +10,15 @@ if [ -z "$DETACH" ]; then
   export DETACH="<Leader>q"
 fi
 
+# Check if VIM is compiled with client-server support
+if ! vim --version | fgrep -q -- '+clientserver'; then
+  # it isn't, use the send-keys hack
+  export VRIM_SENDKEYS=1
+elif vim --version | fgrep -q -- 'MacVim GUI'; then
+  # Only the GUI version (mvim) can act as a server, use the hack
+  export VRIM_SENDKEYS=1
+fi
+
 export VRIM_ID="vrim_$(date +%s)"
 
 if [ ! -x "$(which ranger)" ]; then

--- a/vrim
+++ b/vrim
@@ -21,15 +21,35 @@ if [ -z "$DETACH" ]; then
   exit 1
 fi
 
+REMAP="nnoremap <silent> $DETACH :call system(\"tmux detach -s $VRIM_ID\")"
+
+if [ "$VRIM_SENDKEYS" = "1" ]; then
+  REMAP="$REMAP<CR>"
+  START_VIM_SERVER="vim -c '$REMAP' \"$@\""
+else
+  # note the <LT> workaround to prevent literal <CR>
+  # being interpreted by --remote-silent
+  REMAP="$REMAP<LT>CR>"
+
+  # I haven't found a way to prevent vim from opening a [No Name] buffer first.
+  # This deletes the first buffer.
+  REMOVE_BLANK_BUFFER="bd1"
+
+  START_VIM_SERVER="vim --servername $VRIM_ID --remote-silent +'$REMOVE_BLANK_BUFFER | $REMAP' \"$@\""
+fi
+
 # Check to see if tmux session is running
 if ! tmux has-session -t $VRIM_ID >/dev/null 2>&1; then
   # Start vim server and containing tmux session
-  REMOVE_BLANK_BUFFER="bd1" # I haven't found a way to prevent vim from opening a [No Name] buffer first.  This should remove it.
-  REMAP="nnoremap <silent> $DETACH :call system(\"tmux detach -s $VRIM_ID\")<LT>CR>" # note the <LT> workaround to prevent literal <CR>
-  START_VIM_SERVER="vim --servername $VRIM_ID --remote-silent +'$REMOVE_BLANK_BUFFER | $REMAP' \"$@\""
   exec tmux -2 new-session -s $VRIM_ID "$START_VIM_SERVER" \; set status off \; >/dev/null 2>&1
 else
   # Open requested file and attach to server
-  vim --servername $VRIM_ID --remote "$@"
+  if [ "$VRIM_SENDKEYS" = "1" ]; then
+    tmux send-keys -t $VRIM_ID Escape
+    tmux send-keys -t $VRIM_ID -l ":e $@"
+    tmux send-keys -t $VRIM_ID Enter
+  else
+    vim --servername $VRIM_ID --remote "$@"
+  fi
   exec tmux -2 attach -t $VRIM_ID >/dev/null 2>&1
 fi


### PR DESCRIPTION
Okay, this is the biggie :smile_cat: On Mac, only gvim can be a server. Also, I'd like to use vranger on FreeBSD servers without X. So I wrote this horrible horrible hack which uses `tmux send-keys` to control vim. So far, it seems like it could even work.
